### PR TITLE
Avoid delayed_job debug logs

### DIFF
--- a/config/initializers/active_record_logger.rb
+++ b/config/initializers/active_record_logger.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.logger.level = Logger::INFO


### PR DESCRIPTION
## Objectives

By default, we see many lines this in the logs
```
DEBUG: Delayed::Backend::ActiveRecord::Job Load (1.1ms) ...
```

With this change, we avoid all debug logs for ActiveRecord
Other solutions and more info here https://github.com/collectiveidea/delayed_job/issues/886
