### PR TITLE
Avoid sending ActionController::RoutingError to Errbit

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -8,6 +8,6 @@ Airbrake.configure do |config|
 end
 
 Airbrake.add_filter do |notice|
-  ignorables = %w[ActiveRecord::RecordNotFound]
+  ignorables = %w[ActiveRecord::RecordNotFound ActionController::RoutingError]
   notice.ignore! if ignorables.include? notice[:errors].first[:type]
 end


### PR DESCRIPTION
## Objectives

Most of the times `ActionController::RoutingError` errors are because users modify de URL and are not real errors in the application
