### PR TITLE
Allow deleting polls with answers including videos

### DIFF
--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -9,7 +9,7 @@ class Poll::Question::Answer < ApplicationRecord
   accepts_nested_attributes_for :documents, allow_destroy: true
 
   belongs_to :question, class_name: "Poll::Question"
-  has_many :videos, class_name: "Poll::Question::Answer::Video"
+  has_many :videos, class_name: "Poll::Question::Answer::Video", dependent: :destroy
 
   validates_translation :title, presence: true
   validates :given_order, presence: true, uniqueness: { scope: :question_id }

--- a/spec/features/admin/poll/questions/answers/answers_spec.rb
+++ b/spec/features/admin/poll/questions/answers/answers_spec.rb
@@ -58,4 +58,18 @@ describe "Answers" do
 
     expect("Another title").to appear_before("New title")
   end
+
+  context "Delete" do
+    scenario "Will delete related videos" do
+      poll = create(:poll)
+      question = create(:poll_question, poll: poll)
+      answer = create(:poll_question_answer, question: question, title: "Answer with video")
+      create(:poll_answer_video, answer: answer)
+
+      visit admin_polls_path
+      within("#poll_#{poll.id}") { click_link "Delete" }
+
+      expect(page).to have_content "Poll deleted successfully"
+    end
+  end
 end


### PR DESCRIPTION
## Objectives

Avoid the following error when trying to delete a poll with answers that contain videos.
```
PG::ForeignKeyViolation: ERROR: update or delete on table "poll_question_answers" violates 
foreign key constraint "fk_rails_52941e957e" on table "poll_question_answer_videos" 
DETAIL: Key (id)=(1) is still referenced from table "poll_question_answer_videos". : 
DELETE FROM "poll_question_answers" WHERE "poll_question_answers"."id" = $1
```
Added the option `dependent: :destroy` to the `has_many` relation