### PR TITLE
Find correct path for WickedPdf on production

### DIFF
--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -19,3 +19,9 @@ WickedPdf.config = {
   # (but can be overridden in `render :pdf` calls)
   # layout: 'pdf.html',
 }
+
+unless Rails.env.test? || Rails.env.development?
+  WickedPdf.config = {
+    exe_path: Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
+  }
+end


### PR DESCRIPTION
## References

https://github.com/mileszs/wicked_pdf/issues/758

https://errors.democrateam.com/apps/5dff3119b2aa2903f8364ae0/problems/5eda06e1b2aa2902c6838a46

## Objectives

Avoid error when downloading a PDF poster for a proposal in production environments