### PR TITLE
Add checkbox to use image as background on header cards

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -727,9 +727,6 @@ body > header,
 
   .jumbo {
     background: none;
-    margin-left: calc(#{$global-width / 2} - 50vw);
-    margin-right: calc(#{$global-width / 2} - 50vw);
-    overflow-x: hidden;
 
     @include breakpoint(large) {
       background: none;
@@ -738,6 +735,12 @@ body > header,
       background-size: contain;
       margin-top: $line-height * 2;
       min-height: $line-height * 20;
+    }
+
+    &.header-card-full {
+      margin-left: calc(#{$global-width / 2} - 50vw);
+      margin-right: calc(#{$global-width / 2} - 50vw);
+      overflow-x: hidden;
     }
 
     h1 {

--- a/app/controllers/concerns/admin/widget/cards_actions.rb
+++ b/app/controllers/concerns/admin/widget/cards_actions.rb
@@ -41,7 +41,7 @@ module Admin::Widget::CardsActions
 
     def card_params
       params.require(:widget_card).permit(
-        :link_url, :button_text, :button_url, :alignment, :header, :columns,
+        :link_url, :button_text, :button_url, :alignment, :header, :columns, :background_image,
         translation_params(Widget::Card),
         image_attributes: image_attributes
       )

--- a/app/views/admin/widget/cards/_form.html.erb
+++ b/app/views/admin/widget/cards/_form.html.erb
@@ -48,6 +48,11 @@
         <%= render "images/nested_image", f: f %>
       </div>
     </div>
+    <% if card.header? %>
+      <div class="column margin-bottom">
+        <%= f.check_box :background_image %>
+      </div>
+    <% end %>
     <div class="column">
       <%= f.submit(
         t("admin.homepage.#{admin_submit_action(card)}.#{card.header? ? "submit_header" : "submit_card"}"),

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,25 +1,25 @@
 <% if header.present? %>
-  <div class="header-card jumbo highlight"
-       style="background-image: url(<%= image_path_for(header.image_url(:original)) if header.image.present? %>)">
-    <div class="row">
-      <div class="small-12 large-7 column">
-        <span><%= header.label %></span>
-        <h1><%= header.title %></h1>
+  <% if header.image.present? && header.background_image? %>
+    <div id="header_background_image" class="header-card jumbo highlight header-card-full"
+         style="background-image: url(<%= image_path_for(header.image_url(:original)) %>)">
 
-        <p class="lead"><%= header.description %></p>
+      <%= render "shared/header_content", header: header %>
+    </div>
+  <% elsif header.image.present? %>
+    <div class="header-card jumbo highlight">
+      <div class="row">
+        <%= render "shared/header_content", header: header %>
 
-        <% if header.link_text.present? && header.link_url.present? %>
-          <div class="small-12 medium-6 <%= "small-centered" unless header.image.present? %>">
-            <%= link_to header.link_text, header.link_url, class: "button expanded large" %>
-          </div>
-        <% end %>
-      </div>
-
-      <% if header.image.present? %>
-        <div class="small-12 column hide-for-large">
+        <div id="header_image" class="small-12 medium-6 column">
           <%= image_tag(header.image_url(:large), class: "margin", alt: header.image.title) %>
         </div>
-      <% end %>
+      </div>
     </div>
-  </div>
+  <% else %>
+    <div class="header-card jumbo highlight">
+      <div class="row">
+        <%= render "shared/header_content", header: header %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/shared/_header_content.html.erb
+++ b/app/views/shared/_header_content.html.erb
@@ -1,0 +1,12 @@
+<div class="small-12 medium-6 column">
+  <span><%= header.label %></span>
+  <h1><%= header.title %></h1>
+
+  <p class="lead"><%= header.description %></p>
+
+  <% if header.link_text.present? && header.link_url.present? %>
+    <div class="small-12 medium-6">
+      <%= link_to header.link_text, header.link_url, class: "button expanded large" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -480,6 +480,7 @@ en:
         link_text: Link text
         link_url: Link URL
         columns: Number of columns
+        background_image: "Use image as background"
       widget/card/translation:
         label: Label (optional)
         title: Title

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -480,6 +480,7 @@ es:
         link_text: Texto del enlace
         link_url: URL del enlace
         columns: Número de columnas
+        background_image: "Utilizar la imagen como fondo"
       widget/card/translation:
         label: Etiqueta (opcional)
         title: Título

--- a/db/migrate/20220203110757_add_background_image_to_widget_cards.rb
+++ b/db/migrate/20220203110757_add_background_image_to_widget_cards.rb
@@ -1,0 +1,5 @@
+class AddBackgroundImageToWidgetCards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :widget_cards, :background_image, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_112944) do
+ActiveRecord::Schema.define(version: 2022_02_03_110757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -1754,6 +1754,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_112944) do
     t.integer "cardable_id"
     t.integer "columns", default: 4
     t.string "cardable_type", default: "SiteCustomization::Page"
+    t.boolean "background_image", default: false
     t.index ["cardable_id"], name: "index_widget_cards_on_cardable_id"
   end
 

--- a/spec/system/custom/admin/cards_spec.rb
+++ b/spec/system/custom/admin/cards_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+describe "Cards", :admin do
+  scenario "Create header with image" do
+    visit admin_homepage_path
+    click_link "Create header"
+
+    fill_in "Title", with: "Welcome"
+    fill_in "Description", with: "Header description"
+    attach_image_to_card
+    click_button "Create header"
+
+    expect(page).to have_content "Card created successfully!"
+
+    visit root_path
+
+    expect(page).not_to have_selector "#header_background_image"
+    expect(page).to have_selector "#header_image"
+  end
+
+  scenario "Create header with image as background" do
+    visit admin_homepage_path
+    click_link "Create header"
+
+    fill_in "Title", with: "Welcome"
+    fill_in "Description", with: "Header description"
+    attach_image_to_card
+    check "Use image as background"
+    click_button "Create header"
+
+    expect(page).to have_content "Card created successfully!"
+
+    visit root_path
+
+    expect(page).to have_selector "#header_background_image"
+    expect(page).not_to have_selector "#header_image"
+  end
+
+  scenario "Create header without image" do
+    visit admin_homepage_path
+    click_link "Create header"
+
+    fill_in "Title", with: "Welcome"
+    fill_in "Description", with: "Header description"
+    click_button "Create header"
+
+    expect(page).to have_content "Card created successfully!"
+
+    visit root_path
+
+    expect(page).not_to have_selector "#header_background_image"
+    expect(page).not_to have_selector "#header_image"
+  end
+
+  scenario "Checkbox of image as background does not appear on regular cards" do
+    visit admin_homepage_path
+    click_link "Create card"
+
+    expect(page).not_to have_content "Use image as background"
+  end
+
+  def attach_image_to_card
+    click_link "Add image"
+    attach_file "Choose image", Rails.root.join("spec/fixtures/files/clippy.jpg")
+
+    expect(page).to have_field("widget_card_image_attributes_title", with: "clippy.jpg")
+  end
+end


### PR DESCRIPTION
## Objectives

Add checkbox to use image as background on header cards.

## Visual Changes

### New checkbox on admin/header/card
<img width="1247" alt="checkbox_admin" src="https://user-images.githubusercontent.com/631897/152383783-201b35fd-c37b-43fe-a078-c8b94eaedc01.png">

### Header with regular image (default)
<img width="1322" alt="regular_image" src="https://user-images.githubusercontent.com/631897/152383815-e8ebd800-c3b8-4d3a-b59d-7f9e0c7f9852.png">

### Header with background image
<img width="1464" alt="bg_image" src="https://user-images.githubusercontent.com/631897/152383857-1c713e14-5130-4fd3-9487-18966378d250.png">
