### PR TITLE
Add password note on user registrations new

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -39,7 +39,8 @@
 
       <%= f.email_field :email %>
 
-      <%= f.password_field :password, autocomplete: "off" %>
+      <%= f.password_field :password, autocomplete: "off",
+                           hint: t("devise_views.users.registrations.new.password_note") %>
 
       <%= f.password_field :password_confirmation, autocomplete: "off",
                            label: t("devise_views.users.registrations.new.password_confirmation_label") %>

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -99,6 +99,7 @@ en:
           cancel: Cancel login
           organization_signup: Do you represent an organisation or collective? %{signup_link}
           organization_signup_link: Sign up here
+          password_note: "It should contain at least 8 characters"
           password_confirmation_label: Confirm password
           submit: Register
           terms: By registering you accept the %{terms}

--- a/config/locales/es/devise_views.yml
+++ b/config/locales/es/devise_views.yml
@@ -99,6 +99,7 @@ es:
           cancel: Cancelar login
           organization_signup: '¿Representas a una organización / colectivo? %{signup_link}'
           organization_signup_link: Regístrate aquí
+          password_note: "Debe contener al menos 8 caracteres"
           password_confirmation_label: Repite la contraseña anterior
           submit: Registrarse
           terms: Al registrarte aceptas las %{terms}

--- a/config/locales/nl/devise_views.yml
+++ b/config/locales/nl/devise_views.yml
@@ -99,6 +99,7 @@ nl:
           cancel: Annuleren inloggen
           organization_signup: Vertegenwoordigd u een organisatie of collectief? %{signup_link}
           organization_signup_link: Hier aanmelden
+          password_note: "Deze dient minimaal uit 8 tekens te bestaan"
           password_confirmation_label: Bevestig wachtwoord
           submit: Aanmelden
           terms: Met aanmelding accepteerd u de %{terms}


### PR DESCRIPTION
## Objectives

Add password note on user registrations new form.

## Visual Changes

![password_note](https://user-images.githubusercontent.com/631897/156828139-024e8bf8-97ed-409d-bfb0-45aee8a99e7a.png)

