### PR TITLE
Prevent homepage background image duplication

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -737,11 +737,6 @@ body > header,
       min-height: $line-height * 20;
     }
 
-    &.header-card-full {
-      margin-right: calc(#{$global-width / 2} - 50vw);
-      overflow-x: hidden;
-    }
-
     h1 {
       font-size: rem-calc(48);
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <% if header.present? %>
   <% if header.image.present? && header.background_image? %>
-    <div id="header_background_image" class="header-card jumbo highlight header-card-full"
+    <div id="header_background_image" class="jumbo highlight"
          style="background-image: url(<%= image_path_for(header.image_url(:original)) %>)">
 
       <%= render "shared/header_content", header: header %>


### PR DESCRIPTION
## Objectives

Prevent homepage background image duplication.

When homepage header image is set as background is necessary to remove `header-card` class to avoid image duplication.