### PR TITLE
Import custom SCSS file

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,4 +47,5 @@
 @import "sdg_management/**/*";
 @import "widgets/**/*";
 @import "base";
+@import "custom";
 @import "custom/**/*";


### PR DESCRIPTION
## Objectives

Now in CONSUL there are two possible places to customize the styles, the `stylesheets/custom.scss` file and the `stylesheets/custom/` folder.

It seems that we accidentally deleted the `@import "custom"` which forced us to add all the files inside `stylesheets/custom/`. 😓  

This PR adds it back so we can continue to use the default `stylesheets/custom.scss` file. 😌 