### PR TITLE
Remove roles when block or delete users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -254,6 +254,7 @@ class User < ApplicationRecord
     Proposal.hide_all proposal_ids
     Budget::Investment.hide_all budget_investment_ids
     ProposalNotification.hide_all ProposalNotification.where(author_id: id).ids
+    remove_roles
   end
 
   def full_restore
@@ -286,10 +287,19 @@ class User < ApplicationRecord
       unconfirmed_phone: nil
     )
     identities.destroy_all
+    remove_roles
   end
 
   def erased?
     erased_at.present?
+  end
+
+  def remove_roles
+    Administrator.find_by(user_id: id)&.destroy!
+    Valuator.find_by(user_id: id)&.destroy!
+    Moderator.find_by(user_id: id)&.destroy!
+    Manager.find_by(user_id: id)&.destroy!
+    SDG::Manager.find_by(user_id: id)&.destroy!
   end
 
   def take_votes_if_erased_document(document_number, document_type)

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -235,6 +235,36 @@ describe "Account" do
     expect(page).to have_content "Invalid Email or username or password"
   end
 
+  scenario "Erasing an account remove all roles" do
+    create(:administrator, user: user)
+    create(:valuator, user: user)
+    create(:moderator, user: user)
+    create(:manager, user: user)
+    create(:sdg_manager, user: user)
+
+    visit account_path
+
+    expect(Administrator.count).to eq 1
+    expect(Valuator.count).to eq 1
+    expect(Manager.count).to eq 1
+    expect(SDG::Manager.count).to eq 1
+    expect(Moderator.count).to eq 1
+
+    click_link "Erase my account"
+
+    fill_in "user_erase_reason", with: "I don't want admin or valuate anymore!"
+
+    click_button "Erase my account"
+
+    expect(page).to have_content "Goodbye! Your account has been cancelled. We hope to see you again soon."
+
+    expect(Administrator.count).to eq 0
+    expect(Valuator.count).to eq 0
+    expect(Manager.count).to eq 0
+    expect(SDG::Manager.count).to eq 0
+    expect(Moderator.count).to eq 0
+  end
+
   context "Recommendations" do
     scenario "are enabled by default" do
       visit account_path


### PR DESCRIPTION
## References

https://github.com/consul/consul/issues/3988

## Objectives

Remove roles when a user is blocked or delete their account.
