### PR TITLE
Remove unnecessary alert on legislation processes

### DIFF
--- a/app/views/legislation/processes/_debate.html.erb
+++ b/app/views/legislation/processes/_debate.html.erb
@@ -7,11 +7,3 @@
     <% end %>
   </div>
 </div>
-
-<% if process.questions.any? %>
-  <div class="small-12 medium-3 column">
-    <div class="callout success">
-      <p><%= t("legislation.processes.debate.participate") %></p>
-    </div>
-  </div>
-<% end %>

--- a/app/views/legislation/processes/debate.html.erb
+++ b/app/views/legislation/processes/debate.html.erb
@@ -20,14 +20,6 @@
           <% end %>
         </div>
       </div>
-
-      <% if @process.questions.any? %>
-        <div class="small-12 medium-3 column">
-          <div class="callout success">
-            <p><%= t("legislation.processes.debate.participate") %></p>
-          </div>
-        </div>
-      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -54,7 +54,6 @@ en:
           winners: Selected
       debate:
         empty_questions: There aren't any questions
-        participate: Participate in the debate
       index:
         filter: Filter
         filters:

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -54,7 +54,6 @@ es:
           winners: Seleccionadas
       debate:
         empty_questions: No hay preguntas
-        participate: Realiza tus aportaciones al debate previo participando en los siguientes temas.
       index:
         filter: Filtro
         filters:

--- a/spec/system/legislation/processes_spec.rb
+++ b/spec/system/legislation/processes_spec.rb
@@ -318,7 +318,6 @@ describe "Legislation" do
         end
 
         expect(page).to     have_content("This is the process homepage")
-        expect(page).not_to have_content("Participate in the debate")
       end
 
       scenario "disabled", :with_frozen_time do
@@ -345,7 +344,6 @@ describe "Legislation" do
         visit legislation_process_path(process)
 
         expect(page).to     have_content("This phase is not open yet")
-        expect(page).not_to have_content("Participate in the debate")
       end
 
       scenario "open without questions" do
@@ -353,7 +351,6 @@ describe "Legislation" do
 
         visit legislation_process_path(process)
 
-        expect(page).not_to have_content("Participate in the debate")
         expect(page).not_to have_content("This phase is not open yet")
       end
 
@@ -366,7 +363,6 @@ describe "Legislation" do
 
         expect(page).to     have_content("Question 1")
         expect(page).to     have_content("Question 2")
-        expect(page).to     have_content("Participate in the debate")
         expect(page).not_to have_content("This phase is not open yet")
       end
 

--- a/spec/system/legislation/questions_spec.rb
+++ b/spec/system/legislation/questions_spec.rb
@@ -17,8 +17,6 @@ describe "Legislation" do
     scenario "shows question list" do
       visit legislation_process_path(process)
 
-      expect(page).to have_content("Participate in the debate")
-
       expect(page).to have_content("Question 1")
       expect(page).to have_content("Question 2")
       expect(page).to have_content("Question 3")


### PR DESCRIPTION
## Objectives

Remove unnecessary alert on legislation processes.

## Visual changes
![alert](https://user-images.githubusercontent.com/631897/164070258-bf52aeac-05b9-4054-b956-2c2919131aac.png)
