### PR TITLE
Remove task and columns for custom budgets links

### DIFF
--- a/db/migrate/20220518165937_remove_main_button_text_and_main_button_url.rb
+++ b/db/migrate/20220518165937_remove_main_button_text_and_main_button_url.rb
@@ -1,0 +1,28 @@
+class RemoveMainButtonTextAndMainButtonUrl < ActiveRecord::Migration[5.2]
+  def change
+    if ActiveRecord::Base.connection.column_exists?(:budget_phases, :main_button_url)
+      remove_column :budget_phases, :main_button_url
+    end
+    if ActiveRecord::Base.connection.column_exists?(:budget_phases, :main_button_text)
+      remove_column :budget_phases, :main_button_text
+    end
+    if ActiveRecord::Base.connection.column_exists?(:budget_phase_translations, :main_button_url)
+      remove_column :budget_phase_translations, :main_button_url
+    end
+    if ActiveRecord::Base.connection.column_exists?(:budget_phase_translations, :main_button_text)
+      remove_column :budget_phase_translations, :main_button_text
+    end
+    if ActiveRecord::Base.connection.column_exists?(:budget_translations, :main_button_url)
+      remove_column :budget_translations, :main_button_url
+    end
+    if ActiveRecord::Base.connection.column_exists?(:budget_translations, :main_button_text)
+      remove_column :budget_translations, :main_button_text
+    end
+    if ActiveRecord::Base.connection.column_exists?(:budgets, :main_button_url)
+      remove_column :budgets, :main_button_url
+    end
+    if ActiveRecord::Base.connection.column_exists?(:budgets, :main_button_text)
+      remove_column :budgets, :main_button_text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_03_110757) do
+ActiveRecord::Schema.define(version: 2022_05_18_165937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -321,7 +321,6 @@ ActiveRecord::Schema.define(version: 2022_02_03_110757) do
     t.text "summary"
     t.string "name"
     t.string "main_link_text"
-    t.string "main_button_text"
     t.string "main_link_url"
     t.index ["budget_phase_id"], name: "index_budget_phase_translations_on_budget_phase_id"
     t.index ["locale"], name: "index_budget_phase_translations_on_locale"
@@ -334,7 +333,6 @@ ActiveRecord::Schema.define(version: 2022_02_03_110757) do
     t.datetime "starts_at"
     t.datetime "ends_at"
     t.boolean "enabled", default: true
-    t.string "main_button_url"
     t.index ["ends_at"], name: "index_budget_phases_on_ends_at"
     t.index ["kind"], name: "index_budget_phases_on_kind"
     t.index ["next_phase_id"], name: "index_budget_phases_on_next_phase_id"
@@ -356,7 +354,6 @@ ActiveRecord::Schema.define(version: 2022_02_03_110757) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.string "main_link_text"
-    t.string "main_button_text"
     t.string "main_link_url"
     t.index ["budget_id"], name: "index_budget_translations_on_budget_id"
     t.index ["locale"], name: "index_budget_translations_on_locale"
@@ -402,7 +399,6 @@ ActiveRecord::Schema.define(version: 2022_02_03_110757) do
     t.text "description_informing"
     t.string "voting_style", default: "knapsack"
     t.boolean "published"
-    t.string "main_button_url"
     t.boolean "hide_money", default: false
   end
 

--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -10,35 +10,4 @@ namespace :budgets do
       Budget.last.email_unselected
     end
   end
-
-  desc "Updates custom links for budgets"
-  task custom_links: :environment do
-    Budget.find_each do |budget|
-      unless budget.main_link_url.present? && budget.main_link_text.present?
-        if budget.main_button_url.present?
-          budget.main_link_url = budget.main_button_url
-          budget.save!
-        end
-        if budget.main_button_text.present?
-          budget.main_link_text = budget.main_button_text
-          budget.save!
-        end
-      end
-    end
-
-    Budget::Phase.find_each do |phase|
-      if Budget.find_by(id: phase.budget_id)
-        unless phase.main_link_url.present? && phase.main_link_text.present?
-          if phase.main_button_url.present?
-            phase.main_link_url = phase.main_button_url
-            phase.save!
-          end
-          if phase.main_button_text.present?
-            phase.main_link_text = phase.main_button_text
-            phase.save!
-          end
-        end
-      end
-    end
-  end
 end

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -7,7 +7,6 @@ namespace :consul do
   desc "Runs tasks needed to upgrade from 1.3.0 to 1.4.0"
   task "execute_release_1.4.0_tasks": [
     "active_storage:migrate_from_paperclip",
-    "budgets:custom_links",
     "migrations:migrate_map_location_settings"
   ]
 end


### PR DESCRIPTION
## Objectives

Remove task and columns for custom budgets links.

## Notes

The task `budgets:custom_links` it's not necessary anymore since new installations are using the correct `main_link_text/url` instead of `main_button_text/url`. This PR also cleans the `db/schema.rb` because some forks still having the unused columns. 