### PR TITLE
Add new tags on legislation markdown

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -271,6 +271,26 @@ aside {
   }
 }
 
+.draft-panels {
+
+  .draft-allegation .draft-text a {
+    color: $link;
+  }
+
+  .draft-allegation .draft-text h2 {
+    margin-bottom: $line-height / 3;
+    margin-top: 0;
+  }
+
+  ul,
+  ol {
+
+    li {
+      font-size: $base-font-size;
+    }
+  }
+}
+
 .back {
 
   .icon-angle-left {
@@ -2264,6 +2284,33 @@ footer {
   span {
     font-style: normal;
     text-transform: uppercase;
+  }
+}
+
+.legislation-draft-versions-form .markdown-preview {
+  font-family: "Montserrat", sans-serif !important;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "Montserrat", sans-serif !important;
+    line-height: unset;
+  }
+
+  h1 {
+    font-size: rem-calc(44);
+  }
+
+  h2 {
+    font-size: rem-calc(34);
+  }
+
+  h3 {
+    font-size: rem-calc(24);
+    margin: 0;
   }
 }
 

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -24,7 +24,7 @@ class Legislation::DraftVersion < ApplicationRecord
   def body_html
     renderer = Redcarpet::Render::HTML.new(with_toc_data: true)
 
-    Redcarpet::Markdown.new(renderer).render(body)
+    Redcarpet::Markdown.new(renderer, tables: true).render(body)
   end
 
   def toc_html

--- a/lib/admin_legislation_sanitizer.rb
+++ b/lib/admin_legislation_sanitizer.rb
@@ -1,6 +1,6 @@
 class AdminLegislationSanitizer < WYSIWYGSanitizer
   def allowed_tags
-    super + %w[img h1 h4 h5 h6]
+    super + %w[img h1 h4 h5 h6 hr blockquote code table thead tbody th tr td]
   end
 
   def allowed_attributes

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -23,7 +23,11 @@ describe Legislation::DraftVersion do
     <<~BODY_MARKDOWN
       # Title 1
 
+      ---
+
       Some paragraph.
+
+      > Blockquote
 
       A list:
 
@@ -37,6 +41,13 @@ describe Legislation::DraftVersion do
       # Title 2
 
       Something about this.
+
+      `code`
+
+      | Syntax | Description |
+      | ----------- | ----------- |
+      | Header | Title |
+      | Paragraph | Text |
     BODY_MARKDOWN
   end
 
@@ -44,7 +55,13 @@ describe Legislation::DraftVersion do
     <<~BODY_HTML
       <h1 id="title-1">Title 1</h1>
 
+      <hr>
+
       <p>Some paragraph.</p>
+
+      <blockquote>
+      <p>Blockquote</p>
+      </blockquote>
 
       <p>A list:</p>
 
@@ -60,6 +77,24 @@ describe Legislation::DraftVersion do
       <h1 id="title-2">Title 2</h1>
 
       <p>Something about this.</p>
+
+      <p><code>code</code></p>
+
+      <table><thead>
+      <tr>
+      <th>Syntax</th>
+      <th>Description</th>
+      </tr>
+      </thead><tbody>
+      <tr>
+      <td>Header</td>
+      <td>Title</td>
+      </tr>
+      <tr>
+      <td>Paragraph</td>
+      <td>Text</td>
+      </tr>
+      </tbody></table>
     BODY_HTML
   end
 


### PR DESCRIPTION
## Objectives

Add new tags on legislation markdown: `hr blockquote code table thead tbody th tr td`. Also fixes styles for admin markdown preview.

## Visual Changes

![markdown](https://user-images.githubusercontent.com/631897/174096017-5a2df98a-eb4f-4f0a-a41b-9e4c9cbf09a1.png)
