### PR TITLE
Poll header

### DIFF
--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -22,11 +22,11 @@
       </div>
 
       <div class="small-12 column">
-        <%= translations_form.text_area :summary, rows: 4 %>
+        <%= translations_form.text_area :summary, rows: 4, class: "html-area admin" %>
       </div>
 
       <div class="small-12 column">
-        <%= translations_form.text_area :description, rows: 8 %>
+        <%= translations_form.text_area :description, rows: 8, class: "html-area admin" %>
       </div>
     <% end %>
   </div>

--- a/app/views/polls/_poll_header.html.erb
+++ b/app/views/polls/_poll_header.html.erb
@@ -25,9 +25,15 @@
           <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@poll.description) %>
         </div>
 
-        <a id="poll_description_more_info" data-toggle="poll_description_text" class="button primary">
+        <button type="button" id="read_more" class="button primary" data-toggler="hide"
+                data-toggle="poll_description_text read_more read_less">
           <%= t("polls.show.more_info_title") %>
-        </a>
+        </button>
+
+        <button type="button" id="read_less" class="button primary hide" data-toggler="hide"
+                data-toggle="poll_description_text read_more read_less">
+          <%= t("polls.show.less_info_title") %>
+        </button>
       <% end %>
 
       <%= render SDG::TagListComponent.new(@poll, linkable: false) %>

--- a/app/views/polls/_poll_header.html.erb
+++ b/app/views/polls/_poll_header.html.erb
@@ -9,7 +9,7 @@
 
       <h1><%= @poll.name %></h1>
 
-      <%= auto_link_already_sanitized_html simple_format(@poll.summary) %>
+      <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@poll.summary) %>
 
       <% if @poll.geozones.any? %>
         <ul class="margin-top tags">
@@ -22,7 +22,7 @@
       <% if @poll.description.present? %>
         <div id="poll_description_text" class="hide" data-toggler="hide">
           <h3><%= t("polls.show.more_info_title") %></h3>
-          <%= auto_link_already_sanitized_html simple_format(@poll.description) %>
+          <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@poll.description) %>
         </div>
 
         <a id="poll_description_more_info" data-toggle="poll_description_text" class="button primary">

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -65,18 +65,14 @@
                 <% if answer.description.length > 600 %>
                   <div class="read-more">
                     <button type="button" id="read_more_<%= answer.id %>"
-                            data-toggle="answer_description_<%= answer.id %>
-                                         read_more_<%= answer.id %>
-                                         read_less_<%= answer.id %>"
                             data-toggler="hide"
+                            data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
                             class="button primary">
                       <%= t("polls.show.read_more", answer: answer.title) %>
                     </button>
                     <button type="button" id="read_less_<%= answer.id %>"
-                            data-toggle="answer_description_<%= answer.id %>
-                                         read_more_<%= answer.id %>
-                                         read_less_<%= answer.id %>"
                             data-toggler="hide"
+                            data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
                             class="hide button primary">
                       <%= t("polls.show.read_less", answer: answer.title) %>
                     </button>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -623,6 +623,7 @@ en:
       cant_answer_expired: "This poll has finished."
       cant_answer_wrong_geozone: "This question is not available on your geozone."
       more_info_title: "More information"
+      less_info_title: "Less information"
       more_info_options: "More information about the options"
       documents: Documents
       zoom_plus: Expand image

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -626,6 +626,7 @@ es:
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"
+      less_info_title: "Menos información"
       more_info_options: "Más información sobre las opciones"
       documents: Documentos
       zoom_plus: Ampliar imagen

--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -486,6 +486,7 @@ nl:
       cant_answer_expired: "Deze stemronde is voorbij."
       cant_answer_wrong_geozone: "Deze vraag wordt niet behandeld in uw regio"
       more_info_title: "Meer informatie"
+      less_info_title: "Minder informatie"
       documents: Documenten
       zoom_plus: Afbeelding vergroten
       read_more: "Lees meer over %{answer}"

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -63,8 +63,8 @@ describe "Admin polls", :admin do
     fill_in "Name", with: "Upcoming poll"
     fill_in "poll_starts_at", with: start_date
     fill_in "poll_ends_at", with: end_date
-    fill_in "Summary", with: "Upcoming poll's summary. This poll..."
-    fill_in "Description", with: "Upcomming poll's description. This poll..."
+    fill_in_ckeditor "Summary", with: "Upcoming poll's summary. This poll..."
+    fill_in_ckeditor "Description", with: "Upcomming poll's description. This poll..."
 
     expect(page).not_to have_css("#poll_results_enabled")
     expect(page).not_to have_css("#poll_stats_enabled")
@@ -547,8 +547,8 @@ describe "Admin polls", :admin do
       fill_in "Name", with: "Upcoming poll with SDG related content"
       fill_in "Start Date", with: 1.week.from_now
       fill_in "Closing Date", with: 2.weeks.from_now
-      fill_in "Summary", with: "Upcoming poll's summary. This poll..."
-      fill_in "Description", with: "Upcomming poll's description. This poll..."
+      fill_in_ckeditor "Summary", with: "Upcoming poll's summary. This poll..."
+      fill_in_ckeditor "Description", with: "Upcomming poll's description. This poll..."
 
       click_sdg_goal(17)
       click_button "Create poll"

--- a/spec/system/admin/translatable_spec.rb
+++ b/spec/system/admin/translatable_spec.rb
@@ -248,14 +248,14 @@ describe "Admin edit translatable records", :admin do
       scenario "Updates the field to a blank value" do
         visit path
 
-        expect(page).to have_field "Summary", with: "Summary in English"
+        expect(page).to have_ckeditor "Summary", with: "Summary in English"
 
-        fill_in "Summary", with: ""
+        fill_in_ckeditor "Summary", with: " "
         click_button "Update poll"
 
         visit path
 
-        expect(page).to have_field "Summary", with: ""
+        expect(page).to have_ckeditor "Summary", with: ""
       end
     end
   end

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -364,20 +364,32 @@ describe "Polls" do
 
     scenario "Read more button appears only in long answer descriptions" do
       question = create(:poll_question, poll: poll)
-      create(:poll_question_answer, title: "Long answer", question: question,
-             description: Faker::Lorem.characters(number: 700))
+      answer_long = create(:poll_question_answer, title: "Long answer", question: question,
+                           description: Faker::Lorem.characters(number: 700))
       create(:poll_question_answer, title: "Short answer", question: question,
              description: Faker::Lorem.characters(number: 100))
 
       visit poll_path(poll)
 
+      expect(page).to have_content "Long answer"
       expect(page).to have_content "Short answer"
-      expect(page).to have_content "Short answer"
+      expect(page).to have_css "#answer_description_#{answer_long.id}.answer-description.short"
 
       within "#poll_more_info_answers" do
         expect(page).to have_content "Read more about Long answer"
         expect(page).not_to have_content "Read more about Short answer"
       end
+
+      find("#read_more_#{answer_long.id}").click
+
+      expect(page).to have_content "Read less about Long answer"
+      expect(page).to have_css "#answer_description_#{answer_long.id}.answer-description"
+      expect(page).not_to have_css "#answer_description_#{answer_long.id}.answer-description.short"
+
+      find("#read_less_#{answer_long.id}").click
+
+      expect(page).to have_content "Read more about Long answer"
+      expect(page).to have_css "#answer_description_#{answer_long.id}.answer-description.short"
     end
 
     scenario "Show orbit bullets only when there is more than one image" do

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -231,8 +231,11 @@ describe "Polls" do
       expect(page).to have_content("Question 1 #{proposal_question.title}", normalize_ws: true)
       expect(page).to have_content("Question 2 #{normal_question.title}", normalize_ws: true)
 
-      find("#poll_description_more_info").click
+      find("#read_more").click
       expect(page).to have_content(poll.description)
+
+      find("#read_less").click
+      expect(page).not_to have_content(poll.description)
     end
 
     scenario "Do not show question number in polls with one question" do


### PR DESCRIPTION
## References

Backport of https://github.com/StemvanGroningen/consul/pull/149.

## Objectives

- Add wysiwyg to poll description and summary.
- Add read less button on poll header.
- Fix data-toggle on poll answer description: the data-toggle ids should remain on the same line to work.