### PR TITLE
Show orbit controls on image polls

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -2866,12 +2866,6 @@ footer {
     right: 12px;
     top: 0;
   }
-
-  .zoom-link,
-  .orbit-caption,
-  .orbit-controls {
-    display: none;
-  }
 }
 
 // 12. Users

--- a/app/views/polls/_gallery.html.erb
+++ b/app/views/polls/_gallery.html.erb
@@ -6,14 +6,16 @@
   </button>
 
   <div class="orbit-wrapper">
-    <div class="orbit-controls">
-      <button class="orbit-previous">
-        <span class="show-for-sr"><%= t("shared.orbit.previous_slide") %></span>&#9664;&#xFE0E;
-      </button>
-      <button class="orbit-next">
-        <span class="show-for-sr"><%= t("shared.orbit.next_slide") %></span>&#9654;&#xFE0E;
-      </button>
-    </div>
+    <% if answer.images.count > 1 %>
+      <div class="orbit-controls">
+        <button class="orbit-previous">
+          <span class="show-for-sr"><%= t("shared.orbit.previous_slide") %></span>&#9664;&#xFE0E;
+        </button>
+        <button class="orbit-next">
+          <span class="show-for-sr"><%= t("shared.orbit.next_slide") %></span>&#9654;&#xFE0E;
+        </button>
+      </div>
+    <% end %>
 
     <ul class="orbit-container">
       <% answer.images.reverse.each_with_index do |image, index| %>

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -390,7 +390,7 @@ describe "Polls" do
       expect(page).to have_css "#answer_description_#{answer_long.id}.answer-description.short"
     end
 
-    scenario "Show orbit bullets only when there is more than one image" do
+    scenario "Show orbit bullets and controls only when there is more than one image" do
       poll = create(:poll)
       question = create(:poll_question, poll: poll)
       answer1 = create(:poll_question_answer, title: "Answer with one image", question: question)
@@ -402,10 +402,12 @@ describe "Polls" do
       visit poll_path(poll)
 
       within("#answer_#{answer1.id}_gallery") do
+        expect(page).not_to have_css ".orbit-controls"
         expect(page).not_to have_css "nav.orbit-bullets"
       end
 
       within("#answer_#{answer2.id}_gallery") do
+        expect(page).to have_css ".orbit-controls"
         expect(page).to have_css "nav.orbit-bullets"
       end
     end


### PR DESCRIPTION
## Objectives

Show orbit controls on image polls if there are more than one image.

## Visual changes
![image_controls](https://user-images.githubusercontent.com/631897/184674315-e0883fcb-c4a9-41ea-b37b-d96be5809a2c.png)

