### PR TITLE
Fix budget header for small images

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1260,6 +1260,28 @@ footer {
   }
 }
 
+.budget-header .budgets-index,
+.budget-group-show,
+.budget-groups-index,
+.budget-ballot-show {
+
+  > header {
+
+    &::before {
+      left: 0;
+      right: 0;
+    }
+  }
+}
+
+.budget-header {
+
+  &::before {
+    left: 0;
+    right: 0;
+  }
+}
+
 .budget-phases {
 
   header {


### PR DESCRIPTION
## Objectives

Fix budget header for small images.

## Visual Changes

### Small image on budget header
![image](https://user-images.githubusercontent.com/631897/190272103-58add0d9-90ab-4365-a52e-ac01a90fae4d.jpg)

### Before
![before](https://user-images.githubusercontent.com/631897/190272091-ee9e638a-aae0-41c3-b2c9-516a9525a545.png)

### After
![after](https://user-images.githubusercontent.com/631897/190272084-e8e75ad8-9cd1-40b7-ae43-2fc46dda1306.png)
