### PR TITLE
Design fixes for mobile devices

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -2785,6 +2785,18 @@ footer {
     }
   }
 
+  @include breakpoint(small only) {
+
+    .message {
+      position: unset !important;
+    }
+
+    .table-cell {
+      clear: both;
+      display: block;
+    }
+  }
+
   .question-list {
     font-size: $small-font-size;
 

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -3315,6 +3315,13 @@ footer {
   background: $light;
   padding-bottom: $line-height * 2;
 
+  @include breakpoint(small only) {
+
+    .phases-list {
+      display: none;
+    }
+  }
+
   h2 {
     font-size: $base-font-size;
   }

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -677,6 +677,10 @@ body > header,
 
 .subnavigation {
 
+  @include breakpoint(small only) {
+    padding: 0 !important;
+  }
+
   .dropdown.menu > li {
 
     &.opens-left > .is-dropdown-submenu {
@@ -716,8 +720,8 @@ body > header,
         top: 20px;
 
         @include breakpoint(small only) {
-          right: -10px;
-          top: 8px;
+          right: -10px !important;
+          top: 8px !important;
         }
       }
     }

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1814,6 +1814,25 @@ footer {
   }
 }
 
+a {
+
+  &.legislation-date {
+    display: block;
+
+    &:hover {
+      background: $brand;
+      text-decoration: none;
+
+      h4,
+      p,
+      h4 span,
+      .date-status {
+        color: #fff;
+      }
+    }
+  }
+}
+
 .date-status {
   color: $highlight-text;
   display: block;

--- a/app/views/custom/legislation/processes/_process.html.erb
+++ b/app/views/custom/legislation/processes/_process.html.erb
@@ -28,7 +28,7 @@
     <div class="column row small-collapse medium-uncollapse legislation-calendar">
       <% if process.debate_phase.enabled? %>
         <div class="small-6 medium-<%= column_width %> column end">
-          <div class="legislation-date">
+          <%= link_to debate_legislation_process_path(process), class: "legislation-date" do %>
             <div class="legislation-date-title">
               <h4>
                 <%= t("legislation.processes.shared.debate_dates") %>
@@ -37,13 +37,13 @@
               <p><%= render "legislation/processes/phase_dates", process: process, phase: "debate" %></p>
             </div>
             <%= render "legislation/processes/phase_status", process: process, phase: "debate" %>
-          </div>
+          <% end %>
         </div>
       <% end %>
 
       <% if process.draft_publication.enabled? %>
         <div class="small-6 medium-<%= column_width %> column end">
-          <div class="legislation-date">
+          <%= link_to draft_publication_legislation_process_path(process), class: "legislation-date" do %>
             <div class="legislation-date-title">
               <h4><%= t("legislation.processes.shared.draft_publication_date") %></h4>
               <% if process.draft_publication_date.present? %>
@@ -56,13 +56,13 @@
                 <%= draft_publication_status %>
               </span>
             <% end %>
-          </div>
+          <% end %>
         </div>
       <% end %>
 
       <% if process.proposals_phase.enabled? %>
         <div class="small-6 medium-<%= column_width %> column end">
-          <div class="legislation-date">
+          <%= link_to proposals_legislation_process_path(process), class: "legislation-date" do %>
             <div class="legislation-date-title">
               <h4>
                 <%= t("legislation.processes.shared.proposals_dates") %>
@@ -71,13 +71,13 @@
               <p><%= render "legislation/processes/phase_dates", process: process, phase: "proposals" %></p>
             </div>
             <%= render "legislation/processes/phase_status", process: process, phase: "proposals" %>
-          </div>
+          <% end %>
         </div>
       <% end %>
 
       <% if process.allegations_phase.enabled? %>
         <div class="small-6 medium-<%= column_width %> column end">
-          <div class="legislation-date">
+          <%= link_to allegations_legislation_process_path(process), class: "legislation-date" do %>
             <div class="legislation-date-title">
               <h4>
                 <%= t("legislation.processes.shared.allegations_dates") %>
@@ -90,13 +90,13 @@
               <p><%= render "legislation/processes/phase_dates", process: process, phase: "allegations" %></p>
             </div>
             <%= render "legislation/processes/phase_status", process: process, phase: "allegations" %>
-          </div>
+          <% end %>
         </div>
       <% end %>
 
       <% if process.result_publication.enabled? %>
         <div class="small-6 medium-<%= column_width %> column end">
-          <div class="legislation-date">
+          <%= link_to result_publication_legislation_process_path(process), class: "legislation-date" do %>
             <div class="legislation-date-title">
               <h4><%= t("legislation.processes.shared.result_publication_date") %></h4>
               <% if process.result_publication_date.present? %>
@@ -109,7 +109,7 @@
                 <%= result_publication_status %>
               </span>
             <% end %>
-          </div>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -367,6 +367,14 @@ describe "Budgets" do
     expect(page).to have_css(".tabs-panel.is-active", count: 1)
   end
 
+  scenario "Index phases list do not show on mobile", :small_window do
+    visit budgets_path
+
+    expect(page).not_to have_selector "#budget_phases_tabs"
+    expect(page).not_to have_selector ".phase-title.tabs-title"
+    expect(page).not_to have_selector ".phase-title.tabs-title.is-active.current-phase-tab"
+  end
+
   context "Index map" do
     let(:heading) { create(:budget_heading, budget: budget) }
 

--- a/spec/system/legislation/processes_spec.rb
+++ b/spec/system/legislation/processes_spec.rb
@@ -142,6 +142,41 @@ describe "Legislation" do
       end
     end
 
+    scenario "Participation phases have a link to the corresponding phase" do
+      travel_to "01/06/2020".to_date
+      process = create(:legislation_process, debate_start_date: "01/05/2020",
+                       debate_end_date: "30/05/2020",
+                       proposals_phase_start_date: "01/06/2020",
+                       proposals_phase_end_date: "30/06/2020",
+                       draft_publication_date: "20/05/2020",
+                       allegations_start_date: "01/06/2020",
+                       allegations_end_date: "05/06/2020",
+                       result_publication_date: "01/07/2020")
+
+      phase_debate = ["Debate (0)", "01 May 2020 - 30 May 2020", "LOCKED"].join("\n")
+      phase_draft = ["Draft publication", "20 May 2020", "PUBLISHED"].join("\n")
+      phase_proposals = ["Proposals (0)", "01 Jun 2020 - 30 Jun 2020", "ACTIVE"].join("\n")
+      phase_comments = ["Comments (0)", "01 Jun 2020 - 05 Jun 2020", "ACTIVE"].join("\n")
+      phase_result = ["Final result publication", "01 Jul 2020", "COMING SOON"].join("\n")
+
+      visit legislation_processes_path
+
+      within("#legislation_process_#{process.id} .legislation-calendar") do
+        expect(page).to have_selector("a", text: phase_debate)
+        expect(page).to have_selector("a", text: phase_draft)
+        expect(page).to have_selector("a", text: phase_proposals)
+        expect(page).to have_selector("a", text: phase_comments)
+        expect(page).to have_selector("a", text: phase_result)
+        expect(page).to have_link(href: debate_legislation_process_path(process))
+        expect(page).to have_link(href: draft_publication_legislation_process_path(process))
+        expect(page).to have_link(href: proposals_legislation_process_path(process))
+        expect(page).to have_link(href: allegations_legislation_process_path(process))
+        expect(page).to have_link(href: result_publication_legislation_process_path(process))
+      end
+
+      travel_back
+    end
+
     scenario "Filtering processes" do
       create(:legislation_process, title: "Process open")
       create(:legislation_process, :past, title: "Process past")


### PR DESCRIPTION
## Objectives

- Fix poll message on mobile.
- Fix subnavigation menu on mobile.
- Hide phases list on mobile.
- Add links to legislation processes dates.

## Visual Changes
### Fix poll message on mobile
<img width="493" alt="1_before" src="https://user-images.githubusercontent.com/631897/186480285-2a5e859f-b8fb-47e6-b6f8-a6c5d69b1174.png">
<img width="497" alt="1_after" src="https://user-images.githubusercontent.com/631897/186480295-5154cd9f-7722-4bff-b597-7d5ff3786b6f.png">

### Fix subnavigation menu on mobile
![2_before](https://user-images.githubusercontent.com/631897/186480427-1a7808ce-0d6d-4fc1-8017-30a19b0aedbe.png)
![2_after](https://user-images.githubusercontent.com/631897/186480420-b532f124-a217-4957-94ef-a97420da23a5.png)

### Add links to legislation processes dates
![3](https://user-images.githubusercontent.com/631897/186480456-78ded3c9-e442-44ed-901d-a6dba1f8569e.png)

