### PR TITLE
Show email digest only if proposals are enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
       postgres:
@@ -57,7 +57,7 @@ jobs:
           name: screenshots
           path: tmp/screenshots
   coveralls:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: tests
     env:
       CI_BUILD_NUMBER: ${{ github.run_number }}

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -54,9 +54,11 @@
               <%= f.check_box :newsletter %>
             </div>
 
-            <div>
-              <%= f.check_box :email_digest %>
-            </div>
+            <% if feature?(:proposals) %>
+              <div>
+                <%= f.check_box :email_digest %>
+              </div>
+            <% end %>
 
             <div>
               <%= f.check_box :email_on_direct_message %>

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -107,6 +107,17 @@ describe "Account" do
     expect(find("#account_email_on_comment_reply")).to be_checked
   end
 
+  scenario "Email digest checkbox only appears if proposals are enabled" do
+    visit account_path
+
+    expect(page).to have_field "Receive a summary of proposal notifications", checked: true
+
+    Setting["process.proposals"] = false
+    visit account_path
+
+    expect(page).not_to have_field "Receive a summary of proposal notifications"
+  end
+
   context "Option to display badge for official position" do
     scenario "Users with official position of level 1" do
       official_user = create(:user, official_level: 1)


### PR DESCRIPTION
## Objectives

Users can select the option "**Receive a summary of proposal notifications**" on the My Account `/account` page.

These notifications are created by proposal authors for users who have supported the proposal. 

To avoid confusion and improve the UX, this PR hides that checkbox if the proposals feature is disabled, as it doesn't make sense to show the option if those notifications cannot be created. 😌 

## Visual Changes

![proposals_notifications](https://github.com/consul/consul/assets/631897/65a147f4-98d0-4719-941e-62d43dbd14aa)
