### PR TITLE
Replace format on polls description

### DIFF
--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -14,7 +14,7 @@
   <div class="small-12 column">
     <% if show_polls_description? %>
       <div class="polls-description">
-        <%= auto_link_already_sanitized_html wysiwyg(@active_poll.description) %>
+        <%= auto_link_already_sanitized_html sanitize(@active_poll.description) %>
       </div>
     <% end %>
 


### PR DESCRIPTION
## Objectives

Replace format on polls description. This allows use text format and line breaks on polls description text. 