### PR TITLE
Replace legislation processes form markdown

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1173,11 +1173,11 @@ form {
   }
 
   .html-area:not(.form-error) {
-    height: 272px;
+    height: $line-height * 12;
     margin-bottom: $line-height;
 
     &.admin {
-      height: 572px;
+      height: $line-height * 20;
     }
   }
 

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -167,21 +167,15 @@
       </div>
 
       <div class="small-12 medium-9 column">
-        <%= translations_form.text_area :summary,
-                                        rows: 2,
-                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+        <%= translations_form.text_area :summary, class: "html-area admin" %>
       </div>
 
       <div class="small-12 medium-9 column">
-        <%= translations_form.text_area :description,
-                                        rows: 5,
-                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+        <%= translations_form.text_area :description, class: "html-area admin" %>
       </div>
 
       <div class="small-12 medium-9 column end">
-        <%= translations_form.text_area :additional_info,
-                                        rows: 10,
-                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+        <%= translations_form.text_area :additional_info, class: "html-area admin" %>
       </div>
     <% end %>
   </div>

--- a/app/views/legislation/processes/_header.html.erb
+++ b/app/views/legislation/processes/_header.html.erb
@@ -33,14 +33,14 @@
         <% if header == :small %>
           <% if @process.description.present? %>
             <p class="title"><%= t("legislation.processes.header.description") %></p>
-            <%= markdown @process.description %>
+            <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@process.description) %>
           <% end %>
 
           <div id="legislation_info" class="hide" data-toggler="hide">
             <% if @process.additional_info.present? %>
               <hr>
               <p class="title"><%= t("legislation.processes.header.additional_info") %></p>
-              <%= markdown @process.additional_info %>
+              <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@process.additional_info) %>
             <% end %>
           </div>
 

--- a/app/views/legislation/processes/_header_full.html.erb
+++ b/app/views/legislation/processes/_header_full.html.erb
@@ -1,6 +1,6 @@
 <% if @process.description.present? %>
   <p class="title"><%= t("legislation.processes.header.description") %></p>
-  <%= markdown @process.description %>
+  <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@process.description) %>
 <% end %>
 
 <%= render SDG::TagListComponent.new(@process, linkable: false) %>
@@ -9,7 +9,7 @@
   <div id="legislation_info" class="hide" data-toggler="hide">
     <hr>
     <p class="title"><%= t("legislation.processes.header.additional_info") %></p>
-    <%= markdown @process.additional_info %>
+    <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@process.additional_info) %>
   </div>
 
   <button type="button" id="read_more" class="button" data-toggler="hide"

--- a/app/views/legislation/processes/_process.html.erb
+++ b/app/views/legislation/processes/_process.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="small-12 medium-11 column end">
-      <%= markdown(process.summary.presence || first_paragraph(process.description)) %>
+      <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize((process.summary.presence || first_paragraph(process.description)) %>
     </div>
 
     <div class="small-12 medium-11 column end">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -607,7 +607,6 @@ en:
           draft_phase_description: If this phase is active, the process won't be listed on processes index. Allow to preview the process and create content before the start.
           allegations_phase: Comments phase
           proposals_phase: Proposals phase
-          use_markdown: Use Markdown to format the text
           homepage_description: Here you can explain the content of the process
           banner_title: Header colors
         index:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -654,7 +654,6 @@ es:
           draft_phase_description: Si esta fase está activa, el proceso no aparecerá en la página de procesos. Permite previsualizar el proceso y crear contenido antes del inicio.
           allegations_phase: Fase de comentarios
           proposals_phase: Fase de propuestas
-          use_markdown: Usa Markdown para formatear el texto
           homepage_description: Aquí puedes explicar el contenido del proceso
           banner_title: Colores del encabezado
         index:

--- a/spec/system/admin/legislation/processes_spec.rb
+++ b/spec/system/admin/legislation/processes_spec.rb
@@ -60,8 +60,8 @@ describe "Admin collaborative legislation", :admin do
       click_link "New process"
 
       fill_in "Process Title", with: "An example legislation process"
-      fill_in "Summary", with: "Summary of the process"
-      fill_in "Description", with: "Describing the process"
+      fill_in_ckeditor "Summary", with: "Summary of the process"
+      fill_in_ckeditor "Description", with: "Describing the process"
 
       base_date = Date.current
 
@@ -129,8 +129,8 @@ describe "Admin collaborative legislation", :admin do
       click_link "New process"
 
       fill_in "Process Title", with: "An example legislation process in draft phase"
-      fill_in "Summary", with: "Summary of the process"
-      fill_in "Description", with: "Describing the process"
+      fill_in_ckeditor "Summary", with: "Summary of the process"
+      fill_in_ckeditor "Description", with: "Describing the process"
 
       base_date = Date.current - 2.days
 
@@ -169,7 +169,7 @@ describe "Admin collaborative legislation", :admin do
 
       visit new_admin_legislation_process_path
       fill_in "Process Title", with: "An example legislation process"
-      fill_in "Summary", with: "Summary of the process"
+      fill_in_ckeditor "Summary", with: "Summary of the process"
 
       base_date = Date.current
 
@@ -223,7 +223,7 @@ describe "Admin collaborative legislation", :admin do
       expect(find("#legislation_process_debate_phase_enabled")).to be_checked
       expect(find("#legislation_process_published")).to be_checked
 
-      fill_in "Summary", with: ""
+      fill_in_ckeditor "Summary", with: " "
       click_button "Save changes"
 
       expect(page).to have_content "Process updated successfully"
@@ -324,7 +324,7 @@ describe "Admin collaborative legislation", :admin do
       expect(page).to have_field("Categories", with: "bicycles, pollution, recycling")
 
       within(".admin-content") { click_link "Information" }
-      fill_in "Summary", with: "Summarizing the process"
+      fill_in_ckeditor "Summary", with: "Summarizing the process"
       click_button "Save changes"
 
       visit admin_legislation_process_proposals_path(process)


### PR DESCRIPTION
## Objectives

Replace legislation processes form markdown to CKEditor fields.

## Visual Changes

### Before
![before](https://github.com/democrateam/consul/assets/631897/6c52c49a-a6f6-4e32-a27b-501a3f7f9814)

### After
![after](https://github.com/democrateam/consul/assets/631897/f977c8de-5b32-4ca3-80f1-e23e3441b1ea)
