### PR TITLE
Add admin maps link

### DIFF
--- a/app/components/admin/menu_component.rb
+++ b/app/components/admin/menu_component.rb
@@ -463,6 +463,7 @@ class Admin::MenuComponent < ApplicationComponent
           images_link,
           content_blocks_link,
           local_census_records_link,
+          maps_link,
           class: ("is-active" if settings?)
         )
     end
@@ -522,6 +523,14 @@ class Admin::MenuComponent < ApplicationComponent
         t("admin.menu.local_census_records"),
         admin_local_census_records_path,
         local_census_records?
+      ]
+    end
+
+    def maps_link
+      [
+        t("admin.menu.maps"),
+        admin_maps_path,
+        maps?
       ]
     end
 


### PR DESCRIPTION
## Objectives

Add link to manage maps in the admin section. Maybe removed by error when upgrading to version 2.0.1

## Visual Changes
### BEFORE
![antes](https://github.com/democrateam/consul/assets/942995/d0dd8619-e70c-4106-ae56-71f2199c7dd7)

### AFTER
![despues](https://github.com/democrateam/consul/assets/942995/2400cba0-6d83-47a9-921a-fb4e90bfb815)
